### PR TITLE
ci: add macOS, Linux, Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,136 @@
+name: Build
+
+on: 
+  pull_request: 
+  push: 
+    branches:
+      - "master"
+
+jobs: 
+  build-linux: 
+    name: Build Linux binaries
+    runs-on: ubuntu-20.04
+    steps: 
+      - name: install Linux deps
+        run: sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3
+
+      - uses: actions/checkout@v3
+    
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with: 
+          path: ./depends
+          key: linux-${{ hashFiles('depends/packages/**') }}
+
+      - name: download dependencies
+        run: make -C ./depends download-linux
+
+      - name: build dependencies
+        run: make -C ./depends -j4
+
+      - run: ./autogen.sh
+
+      - run: echo "CONFIG_SITE=$PWD/depends/x86_64-pc-linux-gnu/share/config.site" >> $GITHUB_ENV
+
+      - run: ./configure 
+
+      - run: make -j4
+
+      - uses: actions/upload-artifact@v4
+        with: 
+          name: binaries-Linux
+          if-no-files-found: error
+          path: |
+            src/drivechaind
+            src/drivechain-cli
+            src/qt/drivechain-qt
+
+
+  build-windows: 
+    name: Build Windows binaries
+    runs-on: ubuntu-20.04
+    steps: 
+        # g++-mingw-w64-x86-64 is the cross-compiling toolchain needed for 
+        # producing Windows binaries
+        #
+        # python3 line is needed to make `python` resolve to `python3`
+      - name: install deps
+        run: |
+          sudo apt install g++-mingw-w64-x86-64 \
+                build-essential libtool autotools-dev automake \
+                libssl-dev libevent-dev \
+                pkg-config bsdmainutils curl git \
+                python3-setuptools python-is-python3 \
+        
+      - name: configure the Windows toolchain
+        run: sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+
+      - uses: actions/checkout@v3
+    
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with: 
+          path: ./depends
+          key: windows-${{ hashFiles('depends/packages/**') }}
+        
+      - name: download dependencies
+        run: make -C ./depends download-win
+
+      - name: build dependencies
+        run: make -C ./depends HOST=x86_64-w64-mingw32 -j4
+
+      - run: ./autogen.sh
+
+      - run: echo "CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site" >> $GITHUB_ENV
+
+      - run: ./configure 
+
+      - run: make -j4
+
+      - uses: actions/upload-artifact@v4
+        with: 
+          name: binaries-Windows
+          if-no-files-found: error
+          path: |
+            src/drivechaind.exe
+            src/drivechain-cli.exe
+            src/qt/drivechain-qt.exe
+
+  build-macos: 
+    name: Build macOS binaries
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v3
+    
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with: 
+          path: ./depends
+          key: macos-${{ hashFiles('depends/packages/**') }}          
+      
+      - name: download dependencies
+        run: make -C ./depends download-osx
+
+      - name: Run build in Docker
+        uses: addnab/docker-run-action@v3 
+        with: 
+          image: barebitcoin/testchain-macos-builder
+          options: -v ${{ github.workspace }}:/testchain --workdir=/testchain
+          shell: bash
+          run: |
+            set -e
+
+            make -C depends -j4
+            export CONFIG_SITE=$PWD/depends/x86_64-apple-darwin11/share/config.site
+            ./autogen.sh
+            ./configure
+            make -j4 # Limit the concurrency to prevent OOM
+
+      - uses: actions/upload-artifact@v4
+        with: 
+          name: binaries-macOS
+          if-no-files-found: error
+          path: |
+            src/drivechaind
+            src/drivechain-cli
+            src/qt/drivechain-qt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-Drivechain (BIPs 300+301)
--------------------------
+Mainchain is an implementation of Bitcoin that extends it with Drivechain capabilities.
+
+# Drivechain (BIPs 300+301)
 
 Drivechain allows Bitcoin to create, delete, send BTC to, and receive BTC from “Layer-2”s called “sidechains”. Sidechains are Altcoins that lack a native “coin” – instead, BTC must first be sent over.
 
@@ -12,10 +13,97 @@ https://github.com/bitcoin/bips/blob/master/bip-0301.mediawiki
 Learn more about Drivechain here:
 http://drivechain.info
 
-For an example sidechain implementation, see: https://github.com/drivechain-project/sidechains
+For an example sidechain implementation, see: https://github.com/LayerTwo-Labs/testchain
 
-License
--------
+## Building Mainchain
+
+Mainchain is built and released for Linux, macOS and Windows. The only supported
+way of building Mainchain is through cross-compiling from Linux. If you only want
+to build node binaries, you can disable building the UI through passing `NO_QT=1`
+to the `make -C ./depends` call. If the build crashes unexpectedly, try reducing
+the amount of concurrency by removing the `-j` parameter.
+
+### Linux
+
+These instructions have been tested with Ubuntu 20.04 (Focal).
+
+```bash
+# install build dependencies 
+$ sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3
+
+# compile dependencies
+$ make -C ./depends -j
+
+# Compile binaries
+$ ./autogen.sh
+$ export CONFIG_SITE=$PWD/depends/x86_64-pc-linux-gnu/share/config.site
+$ ./configure
+$ ./make -j
+
+# binaries are located in src/drivechaind, src/drivechain-cli and src/qt/drivechain-qt
+```
+
+### macOS
+
+Building Mainchain requires a very old version of Ubuntu. A version that is 
+known to work is 14.04 (Jerry). An old version of the macOS SDK is also required.
+For convenience, a [Docker image](https://hub.docker.com/r/barebitcoin/mainchain-macos-builder)
+is provided that has all the required build dependencies pre-installed. 
+If you want to set up your local environment to match this, it is recommended
+to take a look at the [Dockerfile](./contrib/Dockerfile.macosbuilder) that 
+produced this image. 
+
+```bash
+# start the Docker container that will build the binaries
+$ docker run --rm -it \
+    --workdir /mainchain -v $PWD:/mainchain \
+    barebitcoin/mainchain-macos-builder bash
+
+
+# from within the Docker container shell
+
+# compile dependencies
+$ make -C ./depends -j
+
+# compile the binaries
+$ export CONFIG_SITE=$PWD/depends/x86_64-apple-darwin11/share/config.site
+$ ./autogen.sh
+$ ./configure.sh
+$ make -j
+
+# binaries are located (on the host machine) 
+# at src/mainchaind, src/mainchain-cli and src/qt/mainchain-qt
+```
+
+### Windows
+
+These instructions have been tested with Ubuntu 20.04 (Focal).
+
+```bash
+# install dependencies
+$ sudo apt install g++-mingw-w64-x86-64 \
+                build-essential libtool autotools-dev automake \
+                libssl-dev libevent-dev \
+                pkg-config bsdmainutils curl git \
+                python3-setuptools python-is-python3 
+
+# configure the Windows toolchain
+$ sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+
+# compile dependencies
+$ make -C ./depends HOST=x86_64-w64-mingw32 -j
+
+# compile the binaries
+$ export CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site
+$ ./autogen.sh
+$ ./configure.sh
+$ make -j
+
+# binaries are located at src/mainchaind.exe, src/mainchain-cli.exe and
+# src/qt/mainchain-qt.exe
+```
+
+# License
 
 Bitcoin Core (and Drivechain) are released under the terms of the MIT license. See [COPYING](COPYING) for more
 information or see https://opensource.org/licenses/MIT.

--- a/contrib/Dockerfile.macosbuilder
+++ b/contrib/Dockerfile.macosbuilder
@@ -1,0 +1,27 @@
+FROM ubuntu:trusty
+
+RUN mkdir -p /work/SDKs
+
+WORKDIR /work
+
+RUN apt-get update
+
+# Needed for TLS to work 
+RUN apt-get install ca-certificates
+
+# General Linux deps
+RUN apt-get -y install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3
+
+# macOS cross-compilation deps
+RUN apt-get -y install curl librsvg2-bin libtiff-tools bsdmainutils cmake imagemagick libcap-dev libz-dev libbz2-dev python-setuptools
+
+ARG SDK_VERSION=10.11
+ARG SDK_FILE=MacOSX${SDK_VERSION}.sdk
+
+RUN curl --fail https://bitcoincore.org/depends-sources/sdks/${SDK_FILE}.tar.gz \
+         --output ${SDK_FILE}.tar.gz \
+         --insecure
+
+RUN tar -C /work/SDKs -xf ${SDK_FILE}.tar.gz
+
+ENV HOST=x86_64-apple-darwin11 SDK_PATH=/work/SDKs


### PR DESCRIPTION
This basically replicates the exact same thing I did for testchain yesterday.